### PR TITLE
Add missing 'rename' extra field.

### DIFF
--- a/audiofile.webform.inc
+++ b/audiofile.webform.inc
@@ -72,6 +72,7 @@ function _webform_edit_audiofile($component) {
 
   $form['extra']['scheme'] = $edit_file['extra']['scheme'];
   $form['extra']['directory'] = $edit_file['extra']['directory'];
+  $form['extra']['rename'] = $edit_file['extra']['rename'];
   return $form;
 }
 


### PR DESCRIPTION
Provides a rename option in the component's edit form (like the file
component).

Without that option being set uploaded files will not get renamed and
stay in temporary:///. This might lead to unwanted data loss.